### PR TITLE
extensions to make kubevela accept wasmcloud Application configs

### DIFF
--- a/vela/application.yml
+++ b/vela/application.yml
@@ -1,0 +1,52 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: my-example-app
+  annotations:
+    version: v0.0.1
+    description: "This is my app"
+spec:
+  components:
+    - name: userinfo
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/fake:1
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 4
+            spread:
+              - name: eastcoast
+                requirements:
+                  zone: us-east-1
+                weight: 80
+              - name: westcoast
+                requirements:
+                  zone: us-west-1
+                weight: 20
+        - type: linkdef
+          properties:
+            target: webcap
+            values:
+              port: 8080
+    - name: webcap
+      type: capability
+      properties:
+        contract: wasmcloud:httpserver
+        image: wasmcloud.azurecr.io/httpserver:0.13.1
+        link_name: default
+    - name: ledblinky
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/ledblinky:0.0.1
+        contract: wasmcloud:blinkenlights
+        # default link name is "default"
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+            spread:
+              - name: haslights
+                requirements:
+                  ledenabled: true
+                # default weight is 100

--- a/vela/application.yml
+++ b/vela/application.yml
@@ -53,3 +53,21 @@ spec:
               - name: haslights
                 requirements:
                   ledenabled: true
+# ---
+# apiVersion: core.oam.dev/v1beta1
+# kind: Application
+# metadata:
+#   name: website
+# spec:
+#   components:
+#     - name: frontend
+#       type: webservice
+#       properties:
+#         image: nginx
+#     - name: backend
+#       type: worker
+#       properties:
+#         image: busybox
+#         cmd:
+#           - sleep
+#           - "1000"

--- a/vela/application.yml
+++ b/vela/application.yml
@@ -7,9 +7,10 @@ metadata:
     description: "This is my app"
 spec:
   components:
-    - name: userinfo
+    - name: userinfo # This is the component I want to deploy
       type: actor
       properties:
+        name: my-fake-actor
         image: wasmcloud.azurecr.io/fake:1
       traits:
         - type: spreadscaler
@@ -24,29 +25,31 @@ spec:
                 requirements:
                   zone: us-west-1
                 weight: 20
+
         - type: linkdef
           properties:
             target: webcap
             values:
               port: 8080
+
     - name: webcap
       type: capability
       properties:
+        name: my-http-cap
         contract: wasmcloud:httpserver
         image: wasmcloud.azurecr.io/httpserver:0.13.1
         link_name: default
+
     - name: ledblinky
       type: capability
       properties:
+        name: my-led-blinker
         image: wasmcloud.azurecr.io/ledblinky:0.0.1
         contract: wasmcloud:blinkenlights
-        # default link name is "default"
       traits:
         - type: spreadscaler
           properties:
-            replicas: 1
             spread:
               - name: haslights
                 requirements:
                   ledenabled: true
-                # default weight is 100

--- a/vela/application.yml
+++ b/vela/application.yml
@@ -53,6 +53,13 @@ spec:
               - name: haslights
                 requirements:
                   ledenabled: true
+
+  workflow:
+    steps:
+      - name: deploy
+        type: apply-remaining
+      - name: read-application
+        type: read-application
 # ---
 # apiVersion: core.oam.dev/v1beta1
 # kind: Application

--- a/vela/crds.yml
+++ b/vela/crds.yml
@@ -1,0 +1,35 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: actors.wasmcloud.com
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: wasmcloud.com
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                name:
+                  type: string
+                image:
+                  type: string
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: actors
+    # singular name to be used as an alias on the CLI and for display
+    singular: actor
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: Actor

--- a/vela/crds.yml
+++ b/vela/crds.yml
@@ -33,3 +33,39 @@ spec:
     singular: actor
     # kind is normally the CamelCased singular type. Your resource manifests use this.
     kind: Actor
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: capabilities.wasmcloud.com
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: wasmcloud.com
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                name:
+                  type: string
+                image:
+                  type: string
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: capabilities
+    # singular name to be used as an alias on the CLI and for display
+    singular: capability
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: Capability

--- a/vela/definitions.yml
+++ b/vela/definitions.yml
@@ -75,3 +75,29 @@ spec:
         parameter: {
             target: string
         }
+---
+apiVersion: core.oam.dev/v1beta1
+kind: WorkflowStepDefinition
+metadata:
+  name: read-application
+spec:
+  schematic:
+    cue:
+      template: |
+        import (
+        	"vela/op"
+          "encoding/json"
+        )
+        application: op.#Read & {
+        	value: {
+        		apiVersion: "core.oam.dev/v1beta1"
+        		kind:       "Application"
+        		metadata: {
+        			name:      context.name
+        		}
+        	}
+        }
+        notify: op.#HTTPPost & {
+           url: "http://host.docker.internal:8081"
+           request: body: json.Marshal(application.value)
+        }

--- a/vela/definitions.yml
+++ b/vela/definitions.yml
@@ -6,7 +6,7 @@ metadata:
 spec:
   workload:
     definition:
-      apiVersion: v1
+      apiVersion: wasmcloud.com/v1
       kind: Actor
   schematic:
     cue:
@@ -16,7 +16,7 @@ spec:
             image: string
         }
         output: {
-            apiVersion: "v1"
+            apiVersion: "wasmcloud.com/v1"
             kind:       "Actor"
             spec: {
               name: parameter.name
@@ -32,8 +32,8 @@ metadata:
 spec:
   workload:
     definition:
-      apiVersion: apps/v1
-      kind: Deployment
+      apiVersion: wasmcloud.com/v1
+      kind: Capability
   schematic:
     cue:
       template: |
@@ -42,9 +42,11 @@ spec:
             image: string
         }
         output: {
-            apiVersion: "apps/v1"
-            kind:       "Deployment"
+            apiVersion: "wasmcloud.com/v1"
+            kind:       "Capability"
             spec: {
+              name: parameter.name
+              image: parameter.image
             }
         }
 ---

--- a/vela/definitions.yml
+++ b/vela/definitions.yml
@@ -1,0 +1,75 @@
+---
+apiVersion: core.oam.dev/v1beta1
+kind: ComponentDefinition
+metadata:
+  name: actor
+spec:
+  workload:
+    definition:
+      apiVersion: v1
+      kind: Actor
+  schematic:
+    cue:
+      template: |
+        parameter: {
+            name:  string
+            image: string
+        }
+        output: {
+            apiVersion: "v1"
+            kind:       "Actor"
+            spec: {
+              name: parameter.name
+              image: parameter.image
+            }
+        }
+
+---
+apiVersion: core.oam.dev/v1beta1
+kind: ComponentDefinition
+metadata:
+  name: capability
+spec:
+  workload:
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+  schematic:
+    cue:
+      template: |
+        parameter: {
+            name:  string
+            image: string
+        }
+        output: {
+            apiVersion: "apps/v1"
+            kind:       "Deployment"
+            spec: {
+            }
+        }
+---
+apiVersion: core.oam.dev/v1beta1
+kind: TraitDefinition
+metadata:
+  name: spreadscaler
+spec:
+  podDisruptive: false
+  schematic:
+    cue:
+      template: |
+        parameter: {
+            replicas: int
+        }
+---
+apiVersion: core.oam.dev/v1beta1
+kind: TraitDefinition
+metadata:
+  name: linkdef
+spec:
+  podDisruptive: false
+  schematic:
+    cue:
+      template: |
+        parameter: {
+            target: string
+        }

--- a/vela/echo.js
+++ b/vela/echo.js
@@ -1,0 +1,21 @@
+const http = require("http");
+
+const hostname = "0.0.0.0";
+const port = 8081;
+
+const server = http.createServer((req, res) => {
+  console.log(`\n${req.method} ${req.url}`);
+  console.log(req.headers);
+
+  req.on("data", function (chunk) {
+    console.log("BODY: " + chunk);
+  });
+
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "text/plain");
+  res.end("Hello World\n");
+});
+
+server.listen(port, hostname, () => {
+  console.log(`Server running at http://${hostname}:${port}/`);
+});


### PR DESCRIPTION
This is just a PoC that we can make kubevela stay out of our way if we wanted to dump everything in a single Application resource.